### PR TITLE
Update to discovery.metthnue.com

### DIFF
--- a/HueLibrary/Bridge.cs
+++ b/HueLibrary/Bridge.cs
@@ -66,7 +66,7 @@ namespace HueLibrary
             {
                 try
                 {
-                    string response = await client.GetStringAsync(new Uri("https://www.meethue.com/api/nupnp"));
+                    string response = await client.GetStringAsync(new Uri("https://discovery.meethue.com/"));
                     if (response == "[]")
                     {
                         return null;


### PR DESCRIPTION
The link meethue.com/api/nupnp no longer works. Switching to discovery.meethue.com fixes this issue.